### PR TITLE
bugfix: cutting out column by column in `generate_env` function 

### DIFF
--- a/libs/poet/environment_evogym_LLM.py
+++ b/libs/poet/environment_evogym_LLM.py
@@ -211,8 +211,6 @@ def process_neighbour(i, j, grid, object_cells, object_type, processed_cells):
     object_cells.append(cell)
     object_type.append(grid[i][j])
 
-    process_neighbour(i + 1, j, grid, object_cells, object_type, processed_cells)
-    process_neighbour(i - 1, j, grid, object_cells, object_type, processed_cells)
     process_neighbour(i, j + 1, grid, object_cells, object_type, processed_cells)
     process_neighbour(i, j - 1, grid, object_cells, object_type, processed_cells)
 


### PR DESCRIPTION
## Feature Description

- 環境ファイルで連続している領域でも、列ごとに分割して保持するように変更

### Example

以下のような環境ファイルを考える。

```text
              ---------		
      ---------	     ---------
-------			          --------
```

**before**

連続する領域はひとまとまりとして扱っていたため、単一のオブジェクトであった

**after**

```
-------
```

```text
      ---------
```

...

と列ごとに切り出し、配列として保持するように変更